### PR TITLE
fix: 修正登出 API 回應較慢時頁面跳轉行為不正確的問題

### DIFF
--- a/public/js/backend.js
+++ b/public/js/backend.js
@@ -196,25 +196,23 @@ document.addEventListener('DOMContentLoaded', function (e) {
           }
         }
 
-        $('#authFailedModal').modal('show');
-        axios.get('/admin/logout').then(function (res) {
-          Cookies.remove('token');
-        })["catch"](function (errors) {
-          alert(errors);
-        })["finally"](function () {
-          if (authFailed && window.location.pathname.search('/admin/authentication') < 0) {
-            setTimeout(function () {
-              document.getElementById('redirector').innerHTML = '系統正在將您重新導向至登入頁面...';
-              window.location.href = '/admin/authentication';
-            }, 2000);
-          } else {
-            if (!authFailed && window.location.pathname.search('/admin/authentication') < 0) {
-              $('#authFailedModal').on('shown.bs.modal', function () {
+        $('#authFailedModal').on('shown.bs.modal', function () {
+          axios.get('/admin/logout').then(function (res) {
+            Cookies.remove('token');
+
+            if (authFailed && window.location.pathname.search('/admin/authentication') < 0) {
+              setTimeout(function () {
+                document.getElementById('redirector').innerHTML = '系統正在將您重新導向至登入頁面...';
                 window.location.href = '/admin/authentication';
-              });
+              }, 2000);
+            } else {
+              window.location.href = '/admin/authentication';
             }
-          }
+          })["catch"](function (errors) {
+            alert(errors);
+          });
         });
+        $('#authFailedModal').modal('show');
       }
     },
     created: function created() {

--- a/resources/js/backend.js
+++ b/resources/js/backend.js
@@ -137,25 +137,22 @@ document.addEventListener('DOMContentLoaded', function (e) {
                         document.body.innerHTML = modal;
                     }
                 }
-                $('#authFailedModal').modal('show');
-                axios.get('/admin/logout').then((res) => {
-                    Cookies.remove('token');
-                }).catch((errors) => {
-                    alert(errors);
-                }).finally(() => {
-                    if (authFailed && window.location.pathname.search('/admin/authentication') < 0) {
-                        setTimeout(function () {
-                            document.getElementById('redirector').innerHTML = '系統正在將您重新導向至登入頁面...';
-                            window.location.href = '/admin/authentication';
-                        }, 2000);
-                    } else {
-                        if (!authFailed && window.location.pathname.search('/admin/authentication') < 0) {
-                            $('#authFailedModal').on('shown.bs.modal', function () {
+                $('#authFailedModal').on('shown.bs.modal', function () {
+                    axios.get('/admin/logout').then((res) => {
+                        Cookies.remove('token');
+                        if (authFailed && window.location.pathname.search('/admin/authentication') < 0) {
+                            setTimeout(function () {
+                                document.getElementById('redirector').innerHTML = '系統正在將您重新導向至登入頁面...';
                                 window.location.href = '/admin/authentication';
-                            });
+                            }, 2000);
+                        } else {
+                            window.location.href = '/admin/authentication';
                         }
-                    }
+                    }).catch((errors) => {
+                        alert(errors);
+                    });
                 });
+                $('#authFailedModal').modal('show');
             }
         },
         created: function () {


### PR DESCRIPTION
問題：
    1. 登出 API 回應比較緩慢時，API 完成登出後頁面不會正常跳轉到登入頁面。

原因：
    1. 該處的事件監聽寫法問題，原本的寫法在 Modal 完全顯示後 API 還沒有回應
       就會導致頁面跳轉的問題。

調整項目：
    1. backend.js:
        - 統一所有的 API 呼叫都在 Modal 完全顯示後才呼叫。
        - 由於 API 是在 Modal 完全顯示後才呼叫，故 API 回應後可以直接跳轉。

Fixed #3 